### PR TITLE
add timeout and maxsize config to the overpass query

### DIFF
--- a/app/utils/overpass.js
+++ b/app/utils/overpass.js
@@ -12,7 +12,7 @@ import osmtogeojson from 'osmtogeojson';
 export function query (format, query) {
   return promiseRetry((retry, number) => {
     console.log('Fetching data from Overpass... Attempt number:', number);
-    return rp(`http://overpass-api.de/api/interpreter?data=[out:${format}];${query}`)
+    return rp(`http://overpass-api.de/api/interpreter?data=[out:${format}][timeout:900][maxsize:2000000000];${query}`)
       .catch(err => {
         // API calls to Overpass are rate limited. Retry if statusCode is 429
         if (err.statusCode === 429) {


### PR DESCRIPTION
Based on the [overpass wiki](https://wiki.openstreetmap.org/wiki/Overpass_API#Resource_management_options_.28osm-script.29) and [this issue](https://github.com/drolbr/Overpass-API/issues/319), here's an approach for being able to query larger areas.