### PR TITLE
Disable timeout for scenario source data path

### DIFF
--- a/app/routes/scenarios--source-data.js
+++ b/app/routes/scenarios--source-data.js
@@ -41,7 +41,8 @@ export default [
         maxBytes: 2 * Math.pow(1024, 3), // 2GB
         output: 'stream',
         parse: true,
-        allow: 'multipart/form-data'
+        allow: 'multipart/form-data',
+        timeout: false
       }
     },
     handler: async (request, reply) => {


### PR DESCRIPTION
Hapi has a default timeout of 10s that was being triggered. Since network requests for file upload easily take longer, it was failing.
The strange part is that data is being transmitted as a stream, so since it is receiving data it shouldn't timeout. Anyway, disabling the timeout fixes the problem.